### PR TITLE
Handler stack: use the static Create method instead of new

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ You can still add other middlewares to the stack, too.
 Just define your stack as usual and then pass it to the throttled client:
 
 ``` php
-$stack = new HandlerStack();
-$stack->setHandler(new CurlHandler());
+$stack = HandlerStack::Create(new CurlHandler());
 $stack->push(some_other_middleware);
 
 $client = GuzzleThrottle::client(['base_uri' => 'https://www.google.com', 'handler' => $stack]);

--- a/src/Helpers/ClientHelper.php
+++ b/src/Helpers/ClientHelper.php
@@ -42,8 +42,7 @@ class ClientHelper extends ServiceProvider
     {
         if (!isset($config[self::HANDLER_KEY]))
         {
-            $stack = new HandlerStack();
-            $stack->setHandler(new CurlHandler());
+            $stack = HandlerStack::create(new CurlHandler());
             $config[self::HANDLER_KEY] = $stack;
         }
 

--- a/src/Helpers/ClientHelper.php
+++ b/src/Helpers/ClientHelper.php
@@ -42,7 +42,8 @@ class ClientHelper extends ServiceProvider
     {
         if (!isset($config[self::HANDLER_KEY]))
         {
-            $stack = HandlerStack::create(new CurlHandler());
+            $stack = new HandlerStack();
+            $stack->setHandler(new CurlHandler());
             $config[self::HANDLER_KEY] = $stack;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use 
```
HandlerStack::create(new CurlHandler());
```
instead of
```
$stack = new HandlerStack();
$stack->setHandler(new CurlHandler());
```
in the ClientHelper

## Motivation and context

The use of `new HandlerStack` was breaking the possibility to use a shared cookie jar by passing `cookies => true` in the GuzzleClient constructor (http://docs.guzzlephp.org/en/stable/quickstart.html#cookies)

I believe it is the recommended way of doing it (http://docs.guzzlephp.org/en/stable/handlers-and-middleware.html)

## How has this been tested?

I ran the tests in the repository.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ x] My pull request addresses exactly one patch/feature.
- [x ] I have created a branch for this patch/feature.
- [x ] Each individual commit in the pull request is meaningful.
- [ x] I have added tests to cover my changes.
- [x ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!